### PR TITLE
Allow python scripting & update operators

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -190,7 +190,7 @@ subpanels = (
 
 class ImportModel(Operator, ImportHelper):
     '''Import a model from Pokémon Battle Revolution'''
-    bl_idname = 'pbr.import'
+    bl_idname = 'pbr.pbrimport'
     bl_label = 'PBR Model (.sdr/.odr/.mdr)'
     bl_options = {'REGISTER', 'UNDO'}
 
@@ -227,7 +227,7 @@ class ImportModel(Operator, ImportHelper):
 
 class ExportModel(Operator, ExportHelper):
     '''Export a model for use in Pokémon Battle Revolution'''
-    bl_idname = 'pbr.export'
+    bl_idname = 'pbr.pbrexport'
     bl_label = 'PBR Model (.sdr)'
     bl_options = {'REGISTER', 'UNDO'}
 


### PR DESCRIPTION
Updated the operators for 
import --> pbrimport 
export --> pbrexport
This was done so that import could be used in a python script. Without the change import got confused with the module import and throws an syntax error

Example:
import bpy

bpy.ops.pbr.pbrimport(filepath="C:\\filepathhere\\151.sdr")
